### PR TITLE
Fixing event bug in ask()

### DIFF
--- a/tropo.class.php
+++ b/tropo.class.php
@@ -102,13 +102,13 @@ class Tropo extends BaseClass {
   	    	$$option = $params[$option];
   	    }
   		}
-	  	$say[] = new Say($ask, $as, null, $voice);
 	  	if (is_array($event)) {
 	  	    // If an event was passed in, add the events to the Ask
     		  foreach ($event as $e => $val){
     		    $say[] = new Say($val, $as, $e, $voice); 
     		  }
 	  	}
+	  	$say[] = new Say($ask, $as, null, $voice);
 	  	$params["mode"] = isset($params["mode"]) ? $params["mode"] : null;
 	  	$params["dtmf"] = isset($params["dtmf"]) ? $params["dtmf"] : null;
 	  	$voice = isset($this->_voice) ? $this->_voice : null;


### PR DESCRIPTION
The code in the README wasn't working as expected because of a bug is how the ask() was generating JSON. Specifically, the "Never heard of it." and "Speak up!" says never got spoken, because the JSON that was output, listed "What is your favorite programming language?" before any of the event specific says... and order apparently matters.

The PHP (from README):

$tropo->ask('What is your favorite programming language?', array(
  'choices'=>'PHP, Ruby(Ruby, Rails, Ruby on Rails), Python, Java(Groovy, Java), Perl',
  'event'=> array(
    'nomatch' => 'Never heard of it.',
    'timeout' => 'Speak up!',
    )
  ));

What the JSON used to look like (this would say "What is your favorite programming language?" every time, no matter the event:

"say":[
               {
                  "value":"What is your favorite programming language?"
               },
               {
                  "event":"nomatch",
                  "value":"Never heard of it."
               },
               {
                  "event":"timeout",
                  "value":"Speak up!"
               }
]

What it looks like now (after the bug fix):

"say":[
               {
                  "event":"nomatch",
                  "value":"Never heard of it."
               },
               {
                  "event":"timeout",
                  "value":"Speak up!"
               },
               {
                  "value":"What is your favorite programming language?"
               },
]
