### PR TITLE
Returning Session Id

### DIFF
--- a/tropo-rest.class.php
+++ b/tropo-rest.class.php
@@ -40,15 +40,16 @@ class SessionAPI extends RestBase {
 	    $result = curl_exec($this->ch);
 	    $error = curl_error($this->ch);
 		parent::__destruct();
-	    
-		if($result === false) {
+
+		//check result and parse
+		if($result === false OR !($xml = new SimpleXMLElement($result))) {
 	    	throw new Exception('An error occurred: '.$error);
-		 } else {
-		   if (strpos($result, self::SessionResponse) === false) {
-		     throw new Exception('An error occurred: Tropo session launch failed.');
-		   }
-		  return true;
-		 }		 
+		} else {
+		  if(!($xml->success == 'true')){
+		    throw new Exception('An error occurred: Tropo session launch failed.');
+		  }
+		  return trim((string) $xml->id);
+	    }		 
 	}	
 }
 


### PR DESCRIPTION
This changes the return type of `createSession()`, but unless someone was testing for a strict `true` value it shouldn't break any code. 

Getting the session id back allows the calling script to also send signals to the call. If there was another way to do this, I overlooked it.
