### PR TITLE
The method signature for the constructor should be the same.

### DIFF
--- a/tropo.class.php
+++ b/tropo.class.php
@@ -634,12 +634,6 @@ class Tropo extends BaseClass {
 abstract class BaseClass {
 
 	/**
-	 * Class constructor
-	 * @abstract __construct()
-	 */
-	abstract public function __construct();
-
-	/**
 	 * toString Function
 	 * @abstract __toString()
 	 */


### PR DESCRIPTION
The Choices class extends BaseClass but has another method signature
for __construct(). Since the existence of a constructor is implied in a
class this abstract mention is not required nor useful.

ps. PHP 5.4 craps out over this change in signature
